### PR TITLE
Update translations

### DIFF
--- a/cs.lproj/Localizable.strings
+++ b/cs.lproj/Localizable.strings
@@ -18,16 +18,16 @@
 "NICKNAME" = "Přezdívka";
 
 /* Body of notification when message previews are disabled */
-"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message";
+"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message"; // Untranslated
 
 /* Reply button title for message notification */
-"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply";
+"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply"; // Untranslated
 
 /* Title of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message"; // Untranslated
 
 /* Body of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry"; // Untranslated
 
 "NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
@@ -37,19 +37,19 @@
 "QUERY_LIST_ADD_NETWORK_MESSAGE" = "Přidejte si první sít stiskem zde!";
 
 /* Accessibility label for connected network status */
-"QUERY_LIST_NETWORK_CONNECTED_STATUS" = "connected";
+"QUERY_LIST_NETWORK_CONNECTED_STATUS" = "connected"; // Untranslated
 
 /* Accessibility label for disconnected network status */
-"QUERY_LIST_NETWORK_DISCONNECTED_STATUS" = "disconnected";
+"QUERY_LIST_NETWORK_DISCONNECTED_STATUS" = "disconnected"; // Untranslated
 
 /* Accessibility label for connecting network status */
-"QUERY_LIST_NETWORK_CONNECTING_STATUS" = "connecting";
+"QUERY_LIST_NETWORK_CONNECTING_STATUS" = "connecting"; // Untranslated
 
 /* Accessibility Label for query */
-"QUERY_LIST_QUERY_LABEL" = "%@ (%@ unread)";
+"QUERY_LIST_QUERY_LABEL" = "%@ (%@ unread)"; // Untranslated
 
 /* Accessibility Label for query with unread mentions */
-"QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)";
+"QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)"; // Untranslated
 
 "QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
 "QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
@@ -87,7 +87,7 @@
 "NETWORK_PASSWORD" = "Heslo";
 "NETWORK_AUTOCONNECT" = "Automaticky připojit";
 "NETWORK_DELETE" = "Odstranit síť";
-"NETWORK_IGNORED_NICKS" = "Ignored Nicknames";
+"NETWORK_IGNORED_NICKS" = "Ignored Nicknames"; // Untranslated
 
 "NETWORK_AUTHENTICATION" = "Ověřování";
 "NETWORK_AUTHENTICATION_USERNAME" = "Uživatelské jméno";
@@ -105,12 +105,12 @@
 "NETWORK_EXPAND" = "Rozbalit";
 "NETWORK_CONNECT" = "Připojit";
 "NETWORK_DISCONNECT" = "Odpojit";
-"NETWORK_CHANGE_NICKNAME" = "Change Nickname";
-"NETWORK_CHANGE_NICKNAME_APPLY" = "Change";
-"NETWORK_CHANNEL_LIST" = "Channel List";
+"NETWORK_CHANGE_NICKNAME" = "Change Nickname"; // Untranslated
+"NETWORK_CHANGE_NICKNAME_APPLY" = "Change"; // Untranslated
+"NETWORK_CHANNEL_LIST" = "Channel List"; // Untranslated
 
-"NETWORK_ORDER" = "Order";
-"NETWORK_REARRANGE" = "Sort Networks";
+"NETWORK_ORDER" = "Order"; // Untranslated
+"NETWORK_REARRANGE" = "Sort Networks"; // Untranslated
 
 "NETWORK_PASSWORD_INCORRECT" = "Nesprávné heslo (%@)";
 
@@ -131,27 +131,27 @@
 "PREFERENCES_INTERFACE_SECTION" = "Rozhraní";
 "PREFERENCES_GENERAL_SECTION" = "Obecné";
 "PREFERENCES_REALNAME" = "Pravé jméno";
-"PREFERENCES_SYSTEM_SETTINGS" = "System Settings";
+"PREFERENCES_SYSTEM_SETTINGS" = "System Settings"; // Untranslated
 
 "FONT_SIZE_TITLE" = "Velikost textu";
-"FONT_SIZE_USE_SYSTEM" = "Use System Settings";
+"FONT_SIZE_USE_SYSTEM" = "Use System Settings"; // Untranslated
 
 "STYLE_TITLE" = "Styl";
 "STYLE_SHOW_TIMESTAMPS" = "Ukázat čas";
 "STYLE_SHOW_JOIN_PART" = "Ukázat připojení/odpojení";
 "STYLE_PREVIEW_LINKS" = "Zobrazovat náhledy odkazů";
 
-"THEME_TITLE" = "Theme";
-"THEME_VARIANT_TITLE" = "Variant (Light/Dark)";
-"THEME_VARIANT_AUTOMATICALLY" = "Switch Automatically";
-"THEME_VARIANT_LIGHT" = "Light";
-"THEME_VARIANT_DARK" = "Dark";
+"THEME_TITLE" = "Theme"; // Untranslated
+"THEME_VARIANT_TITLE" = "Variant (Light/Dark)"; // Untranslated
+"THEME_VARIANT_AUTOMATICALLY" = "Switch Automatically"; // Untranslated
+"THEME_VARIANT_LIGHT" = "Light"; // Untranslated
+"THEME_VARIANT_DARK" = "Dark"; // Untranslated
 
 "GENERAL_AUTO_JOIN_CHANNELS" = "Automaticky se připojit ke kanálům";
 "GENERAL_AUTO_AWAY" = "Auto nedostupný";
 
-"NOTIFICATIONS_TITLE" = "Notifications";
-"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews";
+"NOTIFICATIONS_TITLE" = "Notifications"; // Untranslated
+"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews"; // Untranslated
 
 "MENTIONS_TITLE" = "Zmínění";
 "MENTIONS_ADD_TITLE" = "Přidat klíčové slovo";
@@ -220,17 +220,17 @@
 "QUERY_STATUS_CONNECTING" = "Připojuji...";
 "QUERY_STATUS_NICK_OFFLINE" = "Uživatel je odpojen";
 
-"QUERY_STATUS_NICK_IGNORED" = "Nickname Ignored";
-"QUERY_STATUS_NICK_IGNORED_ACTION" = "Tap here to stop ignoring this user.";
+"QUERY_STATUS_NICK_IGNORED" = "Nickname Ignored"; // Untranslated
+"QUERY_STATUS_NICK_IGNORED_ACTION" = "Tap here to stop ignoring this user."; // Untranslated
 
 /* Accessibility label for nicks in channel button */
-"QUERY_DETAIL_CHANNEL_NICKS_BUTTON_LABEL" = "Channel Members";
+"QUERY_DETAIL_CHANNEL_NICKS_BUTTON_LABEL" = "Channel Members"; // Untranslated
 
 /* Accessibility label for whois user button */
-"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User";
+"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User"; // Untranslated
 
 /* Accessibility label for scroll to bottom button */
-"QUERY_DETAIL_SCROLL_BOTTOM_BUTTON_LABEL" = "Scroll down to bottom of conversation";
+"QUERY_DETAIL_SCROLL_BOTTOM_BUTTON_LABEL" = "Scroll down to bottom of conversation"; // Untranslated
 
 /* Link Preview */
 "QUERY_DETAIL_LINK_PREVIEW_ENABLE" = "Zapněte náhledy odkazů";
@@ -239,25 +239,25 @@
 "QUERY_DETAIL_LINK_PREVIEW_ALL_LINKS" = "Pokaždé";
 
 /* Accessibility label for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message";
+"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message"; // Untranslated
 
 /* Accessibility hint for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options";
+"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options"; // Untranslated
 
 /* Message of alert when opening failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered"; // Untranslated
 
 /* Retry option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again"; // Untranslated
 
 /* Delete option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message"; // Untranslated
 
 /* Cancel option of alert for failed message retry options */
 "QUERY_DETAIL_FAILED_MESSAGE_ALERT_CANCEL" = "Zrušit";
 
-"QUERY_DETAIL_MESSAGE_COPY" = "Copy";
-"QUERY_DETAIL_MESSAGE_MORE" = "More";
+"QUERY_DETAIL_MESSAGE_COPY" = "Copy"; // Untranslated
+"QUERY_DETAIL_MESSAGE_MORE" = "More"; // Untranslated
 
 "QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
 "QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
@@ -303,46 +303,46 @@
 "WHOIS_USER_SECTION" = "Uživatel";
 
 /* Whois Session Information Section */
-"WHOIS_SESSION_SECTION" = "Session Information";
+"WHOIS_SESSION_SECTION" = "Session Information"; // Untranslated
 
 /* Whois Server Information Section */
-"WHOIS_SERVER_SECTION" = "Server Information";
+"WHOIS_SERVER_SECTION" = "Server Information"; // Untranslated
 
 /* Whois User Realname */
-"WHOIS_USER_REALNAME" = "Realname";
+"WHOIS_USER_REALNAME" = "Realname"; // Untranslated
 
 /* Whois User Ident */
-"WHOIS_USER_IDENT" = "Ident";
+"WHOIS_USER_IDENT" = "Ident"; // Untranslated
 
 /* Whois User Hostname */
-"WHOIS_USER_HOSTNAME" = "Hostname";
+"WHOIS_USER_HOSTNAME" = "Hostname"; // Untranslated
 
 /* Whois User Is Network Operator */
-"WHOIS_USER_IS_NETWORK_OPERATOR" = "Network Operator";
+"WHOIS_USER_IS_NETWORK_OPERATOR" = "Network Operator"; // Untranslated
 
 /* Whois User Connection Status */
-"WHOIS_USER_CONNECTION_STATUS" = "Status";
+"WHOIS_USER_CONNECTION_STATUS" = "Status"; // Untranslated
 
 /* Whois User Connection Status (Connected) */
-"WHOIS_USER_CONNECTION_STATUS_CONNECTED" = "Connected";
+"WHOIS_USER_CONNECTION_STATUS_CONNECTED" = "Connected"; // Untranslated
 
 /* Whois User Connection Status (Disconnected) */
-"WHOIS_USER_CONNECTION_STATUS_DISCONNECTED" = "Offline";
+"WHOIS_USER_CONNECTION_STATUS_DISCONNECTED" = "Offline"; // Untranslated
 
 /* Whois Session Idle Time */
-"WHOIS_SESSION_IDLE_TIME" = "Idle";
+"WHOIS_SESSION_IDLE_TIME" = "Idle"; // Untranslated
 
 /* Whois Session Connected Time */
-"WHOIS_SESSION_CONNECTED_TIME" = "Connected";
+"WHOIS_SESSION_CONNECTED_TIME" = "Connected"; // Untranslated
 
 /* Whois Session Using TLS */
-"WHOIS_SESSION_USING_TLS" = "Using TLS";
+"WHOIS_SESSION_USING_TLS" = "Using TLS"; // Untranslated
 
 /* Whois Server Hostname */
-"WHOIS_SERVER_HOSTNAME" = "Server";
+"WHOIS_SERVER_HOSTNAME" = "Server"; // Untranslated
 
 /* Whois Server Information */
-"WHOIS_SERVER_INFO" = "Server Info";
+"WHOIS_SERVER_INFO" = "Server Info"; // Untranslated
 
 /* Media */
 "MEDIA_NOT_PLAYING" = "nic neposlouchá";
@@ -359,26 +359,26 @@
 "NICK_LIST" = "Lidé";
 
 /* Channel List */
-"CHANNEL_LIST_TITLE" = "Channels";
+"CHANNEL_LIST_TITLE" = "Channels"; // Untranslated
 
 /* Channel Detail */
-"CHANNEL_DETAIL_TITLE" = "Channel Settings";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Message Notifications";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "All messages";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Mentions or highlights";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never";
+"CHANNEL_DETAIL_TITLE" = "Channel Settings"; // Untranslated
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Message Notifications"; // Untranslated
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "All messages"; // Untranslated
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Mentions or highlights"; // Untranslated
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never"; // Untranslated
 
-"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
-"CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic"; // Untranslated
+"CHANNEL_DETAIL_NO_TOPIC" = "No Topic"; // Untranslated
 "CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
 
 "CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
-"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
+"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes"; // Untranslated
 
 /* Modes View (View/Edit) Title */
-"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes"; // Untranslated
 
 "CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
 "CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated

--- a/cs.lproj/Localizable.strings
+++ b/cs.lproj/Localizable.strings
@@ -11,6 +11,9 @@
 "CANCEL" = "Zrušit";
 "CLOSE" = "Zavřít";
 "OK" = "OK";
+"YES" = "Yes"; // Untranslated
+"NO" = "No"; // Untranslated
+"UNKNOWN" = "Unknown"; // Untranslated
 
 "NICKNAME" = "Přezdívka";
 
@@ -25,6 +28,8 @@
 
 /* Body of notification when sending a message from a notification failed */
 "NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+
+"NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
 "QUERY_LIST_TITLE" = "Žádosti";
 "QUERY_LIST_TITLE_UNREAD" = "Žádosti (%@)";
@@ -45,6 +50,9 @@
 
 /* Accessibility Label for query with unread mentions */
 "QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)";
+
+"QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
+"QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
 
 "NETWORK_ADD" = "Přidat síť";
 "CHANNEL_ADD" = "Přidat kanál";
@@ -251,6 +259,10 @@
 "QUERY_DETAIL_MESSAGE_COPY" = "Copy";
 "QUERY_DETAIL_MESSAGE_MORE" = "More";
 
+"QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
+"QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
+"QUERY_DETAIL_REACTION_TEMPLATE" = "%@ reacted with %@"; // Untranslated
+
 /* Input bar */
 
 "INPUT_UPLOAD_IMAGE_LABEL" = "Odeslat obrázek";
@@ -268,6 +280,16 @@
 "UPLOAD_IMAGE_POLICY_AGREE" = "Souhlasím";
 
 "UPLOAD_IMAGE_PREFERENCES_TITLE" = "Nahrané obrázky";
+"UPLOAD_IMAGE_PREFERENCES_LOGIN" = "Login"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_LOGOUT" = "Logout"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_ACCOUNT" = "Account"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_CHECKING" = "Checking account details"; // Untranslated
+
+"UPLOAD_IMAGE_ERROR_VIEW_SETTINGS" = "View Settings"; // Untranslated
+"UPLOAD_IMAGE_ERROR_ACCESS_NOT_PERMITTED" = "Access to photo library is not permitted. Enable access to photos in system settings."; // Untranslated
+"UPLOAD_IMAGE_ERROR_PARENTAL_CONTROL" = "Parental controls prevent access to photos."; // Untranslated
+"UPLOAD_IMAGE_ERROR_NO_IMAGE" = "Server did not return a string containing the image URL."; // Untranslated
+"UPLOAD_IMAGE_ERROR_INVALID_IMAGE" = "Invalid Image."; // Untranslated
 
 "CLOUDAPP_VERIFY_FAILURE" = "Účet se nepodařilo ověřit, zkuste to prosím znovu.";
 "CLOUDAPP_USERNAME" = "Email";
@@ -341,16 +363,84 @@
 
 /* Channel Detail */
 "CHANNEL_DETAIL_TITLE" = "Channel Settings";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS" = "Message Notifications";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Message Notifications";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "All messages";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Mentions or highlights";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never";
 
 "CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
 "CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
+
+"CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
 "CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
 
 /* Modes View (View/Edit) Title */
 "CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+
+"CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
+"CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated
+"CHANNEL_MODE_M" = "Moderated (+m)"; // Untranslated
+"CHANNEL_MODE_P" = "Private (+p)"; // Untranslated
+"CHANNEL_MODE_S" = "Secret (+s)"; // Untranslated
+"CHANNEL_MODE_N" = "No external messages (+n)"; // Untranslated
+"CHANNEL_MODE_T" = "Only ops can set topic (+t)"; // Untranslated
+
+"CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
+
+/* URL Actions */
+"URL_ACTION_OPEN" = "Open"; // Untranslated
+"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
+"URL_ACTION_COPY" = "Copy"; // Untranslated
+"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
+
+/* Add Network */
+"ADD_NETWORK_POPULAR" = "Popular Networks"; // Untranslated
+"ADD_NETWORK_CUSTOM" = "Custom Network"; // Untranslated
+"ADD_NETWORK_SELECT" = "Select Network"; // Untranslated
+
+/* Connection Details */
+"CONNECTION_DETAIL_TITLE" = "Connection Info"; // Untranslated
+"CONNECTION_DETAIL_CHAIN" = "Certificate Chain"; // Untranslated
+"CERTIFICATE_DETAIL_FINGERPRINTS" = "Fingerprints"; // Untranslated
+
+/* Key Commands */
+"KEY_COMMAND_PREVIOUS_QUERY" = "Previous Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_UNREAD_QUERY" = "Previous Unread Query"; // Untranslated
+"KEY_COMMAND_NEXT_QUERY" = "Next Query"; // Untranslated
+"KEY_COMMAND_NEXT_UNREAD_QUERY" = "Next Unread Query"; // Untranslated
+"KEY_COMMAND_CLOSE_QUERY" = "Close Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_MESSAGE" = "Previous Message"; // Untranslated
+"KEY_COMMAND_NEXT_MESSAGE" = "Next Message"; // Untranslated
+
+/* User Commands */
+"COMMAND_NOT_CONNECTED" = "You are not connected"; // Untranslated
+"COMMAND_NOT_CONNECTED_NICK" = "'%@' alias uses {nick} while we are not connected to a server"; // Untranslated
+"COMMAND_NOT_CONNECTED_CHANNEL" = "'%@' alias uses {channel} while we are not in a channel query"; // Untranslated
+"COMMAND_NOT_JOINED" = "You are not joined"; // Untranslated
+
+"COMMAND_QUERY_INVALID" = "Not a query"; // Untranslated
+"COMMAND_QUERY_UNKNOWN" = "This query is not a channel or nick."; // Untranslated
+"COMMAND_QUERY_INVALID_TYPE" = "Incorrect query type"; // Untranslated
+"COMMAND_NETWORK_INVALID" = "Not a network query"; // Untranslated
+"COMMAND_NETWORK_NOT_FOUND" = "network '%@' not found"; // Untranslated
+"COMMAND_CHANNEL_INVALID" = "%@ is not a channel"; // Untranslated
+"COMMAND_CHANNEL_NOT_JOINED" = "%@ is not joined"; // Untranslated
+
+"COMMAND_RAW_NO_LINE" = "/raw was not given a line"; // Untranslated
+
+"COMMAND_ALIAS_DEFAULT_TITLE" = "Default Aliases:"; // Untranslated
+"COMMAND_ALIAS_TITLE" = "Aliases:"; // Untranslated
+"COMMAND_ALIAS_ALREADY_ADDED" = "Alias '%@' is already added"; // Untranslated
+"COMMAND_ALIAS_NOT_FOUND" = "Alias '%@' not found"; // Untranslated
+"COMMAND_ALIAS_REMOVE_ERROR" = "Cannot remove default alias '%@'"; // Untranslated
+"COMMAND_ALIAS_REMOVE" = "Alias '%@' removed"; // Untranslated
+
+"COMMAND_INVITE_MULTIPLE" = "Multiple channels provided to invite. Only one is allowed."; // Untranslated
+"COMMAND_MY_VERSION" = "/me is using {app} {appVersion} {appURL}"; // Untranslated
+"COMMAND_SYSINFO" = "/me is using {app} {appVersion} on an {platform} running {os} {osVersion}"; // Untranslated
+
+"COMMAND_UNKNOWN" = "Unknown Command: %@"; // Untranslated

--- a/cs.lproj/Localizable.strings
+++ b/cs.lproj/Localizable.strings
@@ -391,10 +391,10 @@
 "CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
 
 /* URL Actions */
-"URL_ACTION_OPEN" = "Open"; // Untranslated
-"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
-"URL_ACTION_COPY" = "Copy"; // Untranslated
-"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"URL_ACTION_OPEN" = "Otevřít";
+"URL_ACTION_READING_LIST" = "Přidat do seznamu četby";
+"URL_ACTION_COPY" = "Kopírovat";
+"URL_ACTION_SHARE" = "Sdílet...";
 "READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
 
 /* Add Network */

--- a/cs.lproj/Localizable.strings
+++ b/cs.lproj/Localizable.strings
@@ -263,14 +263,12 @@
 "UPLOAD_IMAGE_UPLOADING" = "Nahrávání";
 
 "UPLOAD_IMAGE_POLICY_TITLE" = "Nahrání obrázku";
-"UPLOAD_IMAGE_POLICY_BODY" = "Uploading images is done via a third-party service, %@. Tapping below will agree to the privacy policy.";
 "UPLOAD_IMAGE_POLICY_BODY" = "Nahrávání obrázků provozuje třetí strana, %@. Stisknutím níže souhlasíte s jejich zásadami ochrany osobních údajů.";
 "UPLOAD_IMAGE_POLICY_VIEW" = "Zobrazit zásady ochrany osobních údajů";
 "UPLOAD_IMAGE_POLICY_AGREE" = "Souhlasím";
 
 "UPLOAD_IMAGE_PREFERENCES_TITLE" = "Nahrané obrázky";
 
-"CLOUDAPP_VERIFY_FAILURE" = "Account could not be verified, please try again.";
 "CLOUDAPP_VERIFY_FAILURE" = "Účet se nepodařilo ověřit, zkuste to prosím znovu.";
 "CLOUDAPP_USERNAME" = "Email";
 "CLOUDAPP_PASSWORD" = "Heslo";
@@ -278,10 +276,6 @@
 /* Whois */
 "NICK_WHOIS" = "Whois";
 "WHOIS_CHANNELS_TITLE" = "Kanály";
-
-/* Whois */
-"NICK_WHOIS" = "Whois";
-"WHOIS_CHANNELS_TITLE" = "Channels";
 
 /* Whois User Information Section */
 "WHOIS_USER_SECTION" = "Uživatel";

--- a/de.lproj/Localizable.strings
+++ b/de.lproj/Localizable.strings
@@ -18,16 +18,16 @@
 "NICKNAME" = "Nickname";
 
 /* Body of notification when message previews are disabled */
-"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message";
+"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message"; // Untranslated
 
 /* Reply button title for message notification */
-"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply";
+"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply"; // Untranslated
 
 /* Title of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message"; // Untranslated
 
 /* Body of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry"; // Untranslated
 
 "NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
@@ -37,19 +37,19 @@
 "QUERY_LIST_ADD_NETWORK_MESSAGE" = "Tippe hier, um das erste Netzwerk hinzuzufügen!";
 
 /* Accessibility label for connected network status */
-"QUERY_LIST_NETWORK_CONNECTED_STATUS" = "connected";
+"QUERY_LIST_NETWORK_CONNECTED_STATUS" = "connected"; // Untranslated
 
 /* Accessibility label for disconnected network status */
-"QUERY_LIST_NETWORK_DISCONNECTED_STATUS" = "disconnected";
+"QUERY_LIST_NETWORK_DISCONNECTED_STATUS" = "disconnected"; // Untranslated
 
 /* Accessibility label for connecting network status */
-"QUERY_LIST_NETWORK_CONNECTING_STATUS" = "connecting";
+"QUERY_LIST_NETWORK_CONNECTING_STATUS" = "connecting"; // Untranslated
 
 /* Accessibility Label for query */
-"QUERY_LIST_QUERY_LABEL" = "%@ (%@ unread)";
+"QUERY_LIST_QUERY_LABEL" = "%@ (%@ unread)"; // Untranslated
 
 /* Accessibility Label for query with unread mentions */
-"QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)";
+"QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)"; // Untranslated
 
 "QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
 "QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
@@ -68,8 +68,8 @@
 "NICK_CHANNEL_VOICE" = "Voice setzen";
 "NICK_CHANNEL_DEOP" = "Op entfernen";
 "NICK_CHANNEL_DEVOICE" = "Voice entfernen";
-"NICK_IGNORE" = "Ignore";
-"NICK_UNIGNORE" = "Stop Ignoring";
+"NICK_IGNORE" = "Ignore"; // Untranslated
+"NICK_UNIGNORE" = "Stop Ignoring"; // Untranslated
 
 "CHANNEL_ADD_CHANNEL_NAME" = "Name";
 "CHANNEL_ADD_PLACEHOLDER_CHANNEL" = "#palaver";
@@ -105,12 +105,12 @@
 "NETWORK_EXPAND" = "Aufklappen";
 "NETWORK_CONNECT" = "Verbinden";
 "NETWORK_DISCONNECT" = "Trennen";
-"NETWORK_CHANGE_NICKNAME" = "Change Nickname";
-"NETWORK_CHANGE_NICKNAME_APPLY" = "Change";
-"NETWORK_CHANNEL_LIST" = "Channel List";
+"NETWORK_CHANGE_NICKNAME" = "Change Nickname"; // Untranslated
+"NETWORK_CHANGE_NICKNAME_APPLY" = "Change"; // Untranslated
+"NETWORK_CHANNEL_LIST" = "Channel List"; // Untranslated
 
-"NETWORK_ORDER" = "Order";
-"NETWORK_REARRANGE" = "Sort Networks";
+"NETWORK_ORDER" = "Order"; // Untranslated
+"NETWORK_REARRANGE" = "Sort Networks"; // Untranslated
 
 "NETWORK_PASSWORD_INCORRECT" = "Falsches Passwort (%@)";
 
@@ -150,8 +150,8 @@
 "GENERAL_AUTO_JOIN_CHANNELS" = "Räume auto. betreten";
 "GENERAL_AUTO_AWAY" = "Auto. abwesend";
 
-"NOTIFICATIONS_TITLE" = "Notifications";
-"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews";
+"NOTIFICATIONS_TITLE" = "Notifications"; // Untranslated
+"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews"; // Untranslated
 
 "MENTIONS_TITLE" = "Erwähnungen";
 "MENTIONS_ADD_TITLE" = "Neues Schlüsselwort";
@@ -186,25 +186,25 @@
 "IRC_DISCONNECTED" = "Verbindung getrennt";
 "IRC_DISCONNECTED_ERROR" = "Verbindung getrennt (%@)";
 
-"IRC_CHANNEL_MODE_q" = "Owner";
-"IRC_CHANNEL_MODE_PLURAL_q" = "Owners";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_q" = "Owners";
+"IRC_CHANNEL_MODE_q" = "Owner"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_q" = "Owners"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_q" = "Owners"; // Untranslated
 
-"IRC_CHANNEL_MODE_a" = "Protected";
-"IRC_CHANNEL_MODE_PLURAL_a" = "Protected";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_a" = "Protected";
+"IRC_CHANNEL_MODE_a" = "Protected"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_a" = "Protected"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_a" = "Protected"; // Untranslated
 
-"IRC_CHANNEL_MODE_o" = "Op";
-"IRC_CHANNEL_MODE_PLURAL_o" = "Ops";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_o" = "Operators";
+"IRC_CHANNEL_MODE_o" = "Op"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_o" = "Ops"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_o" = "Operators"; // Untranslated
 
-"IRC_CHANNEL_MODE_h" = "Half-op";
-"IRC_CHANNEL_MODE_PLURAL_h" = "Half-ops";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_h" = "Half-Operators";
+"IRC_CHANNEL_MODE_h" = "Half-op"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_h" = "Half-ops"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_h" = "Half-Operators"; // Untranslated
 
-"IRC_CHANNEL_MODE_v" = "Voice";
-"IRC_CHANNEL_MODE_PLURAL_v" = "Voiced";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_v" = "Voiced";
+"IRC_CHANNEL_MODE_v" = "Voice"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_v" = "Voiced"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_v" = "Voiced"; // Untranslated
 
 /* Notifications */
 "IRC_CHANNEL_INVITATION" = "%@ hat dich eingeladen %@ auf %@ zu betreten";
@@ -224,13 +224,13 @@
 "QUERY_STATUS_NICK_IGNORED_ACTION" = "Tippe, um diesen Nutzer nicht mehr zu ignorieren.";
 
 /* Accessibility label for nicks in channel button */
-"QUERY_DETAIL_CHANNEL_NICKS_BUTTON_LABEL" = "Channel Members";
+"QUERY_DETAIL_CHANNEL_NICKS_BUTTON_LABEL" = "Channel Members"; // Untranslated
 
 /* Accessibility label for whois user button */
-"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User";
+"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User"; // Untranslated
 
 /* Accessibility label for scroll to bottom button */
-"QUERY_DETAIL_SCROLL_BOTTOM_BUTTON_LABEL" = "Scroll down to bottom of conversation";
+"QUERY_DETAIL_SCROLL_BOTTOM_BUTTON_LABEL" = "Scroll down to bottom of conversation"; // Untranslated
 
 /* Link Preview */
 "QUERY_DETAIL_LINK_PREVIEW_ENABLE" = "Linkvorschau aktivieren";
@@ -239,25 +239,25 @@
 "QUERY_DETAIL_LINK_PREVIEW_ALL_LINKS" = "Immer";
 
 /* Accessibility label for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message";
+"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message"; // Untranslated
 
 /* Accessibility hint for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options";
+"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options"; // Untranslated
 
 /* Message of alert when opening failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered"; // Untranslated
 
 /* Retry option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again"; // Untranslated
 
 /* Delete option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message"; // Untranslated
 
 /* Cancel option of alert for failed message retry options */
 "QUERY_DETAIL_FAILED_MESSAGE_ALERT_CANCEL" = "Abbrechen";
 
-"QUERY_DETAIL_MESSAGE_COPY" = "Copy";
-"QUERY_DETAIL_MESSAGE_MORE" = "More";
+"QUERY_DETAIL_MESSAGE_COPY" = "Copy"; // Untranslated
+"QUERY_DETAIL_MESSAGE_MORE" = "More"; // Untranslated
 
 "QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
 "QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
@@ -303,46 +303,46 @@
 "WHOIS_USER_SECTION" = "Benutzer";
 
 /* Whois Session Information Section */
-"WHOIS_SESSION_SECTION" = "Session Information";
+"WHOIS_SESSION_SECTION" = "Session Information"; // Untranslated
 
 /* Whois Server Information Section */
-"WHOIS_SERVER_SECTION" = "Server Information";
+"WHOIS_SERVER_SECTION" = "Server Information"; // Untranslated
 
 /* Whois User Realname */
-"WHOIS_USER_REALNAME" = "Realname";
+"WHOIS_USER_REALNAME" = "Realname"; // Untranslated
 
 /* Whois User Ident */
-"WHOIS_USER_IDENT" = "Ident";
+"WHOIS_USER_IDENT" = "Ident"; // Untranslated
 
 /* Whois User Hostname */
-"WHOIS_USER_HOSTNAME" = "Hostname";
+"WHOIS_USER_HOSTNAME" = "Hostname"; // Untranslated
 
 /* Whois User Is Network Operator */
-"WHOIS_USER_IS_NETWORK_OPERATOR" = "Network Operator";
+"WHOIS_USER_IS_NETWORK_OPERATOR" = "Network Operator"; // Untranslated
 
 /* Whois User Connection Status */
-"WHOIS_USER_CONNECTION_STATUS" = "Status";
+"WHOIS_USER_CONNECTION_STATUS" = "Status"; // Untranslated
 
 /* Whois User Connection Status (Connected) */
-"WHOIS_USER_CONNECTION_STATUS_CONNECTED" = "Connected";
+"WHOIS_USER_CONNECTION_STATUS_CONNECTED" = "Connected"; // Untranslated
 
 /* Whois User Connection Status (Disconnected) */
-"WHOIS_USER_CONNECTION_STATUS_DISCONNECTED" = "Offline";
+"WHOIS_USER_CONNECTION_STATUS_DISCONNECTED" = "Offline"; // Untranslated
 
 /* Whois Session Idle Time */
-"WHOIS_SESSION_IDLE_TIME" = "Idle";
+"WHOIS_SESSION_IDLE_TIME" = "Idle"; // Untranslated
 
 /* Whois Session Connected Time */
-"WHOIS_SESSION_CONNECTED_TIME" = "Connected";
+"WHOIS_SESSION_CONNECTED_TIME" = "Connected"; // Untranslated
 
 /* Whois Session Using TLS */
-"WHOIS_SESSION_USING_TLS" = "Using TLS";
+"WHOIS_SESSION_USING_TLS" = "Using TLS"; // Untranslated
 
 /* Whois Server Hostname */
-"WHOIS_SERVER_HOSTNAME" = "Server";
+"WHOIS_SERVER_HOSTNAME" = "Server"; // Untranslated
 
 /* Whois Server Information */
-"WHOIS_SERVER_INFO" = "Server Info";
+"WHOIS_SERVER_INFO" = "Server Info"; // Untranslated
 
 /* Media */
 "MEDIA_NOT_PLAYING" = "spielt gerade nichts ab";
@@ -368,17 +368,17 @@
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Erwähnungen/Hervorhebungen";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Niemals";
 
-"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
-"CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic"; // Untranslated
+"CHANNEL_DETAIL_NO_TOPIC" = "No Topic"; // Untranslated
 "CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
 
 "CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
-"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
+"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes"; // Untranslated
 
 /* Modes View (View/Edit) Title */
-"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes"; // Untranslated
 
 "CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
 "CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated

--- a/de.lproj/Localizable.strings
+++ b/de.lproj/Localizable.strings
@@ -391,10 +391,10 @@
 "CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
 
 /* URL Actions */
-"URL_ACTION_OPEN" = "Open"; // Untranslated
-"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
-"URL_ACTION_COPY" = "Copy"; // Untranslated
-"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"URL_ACTION_OPEN" = "Öffnen";
+"URL_ACTION_READING_LIST" = "Zur Leseliste hinzufügen";
+"URL_ACTION_COPY" = "Kopieren";
+"URL_ACTION_SHARE" = "Teilen...";
 "READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
 
 /* Add Network */

--- a/de.lproj/Localizable.strings
+++ b/de.lproj/Localizable.strings
@@ -11,6 +11,9 @@
 "CANCEL" = "Abbrechen";
 "CLOSE" = "Schließen";
 "OK" = "Ok";
+"YES" = "Yes"; // Untranslated
+"NO" = "No"; // Untranslated
+"UNKNOWN" = "Unknown"; // Untranslated
 
 "NICKNAME" = "Nickname";
 
@@ -25,6 +28,8 @@
 
 /* Body of notification when sending a message from a notification failed */
 "NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+
+"NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
 "QUERY_LIST_TITLE" = "Räume";
 "QUERY_LIST_TITLE_UNREAD" = "Räume (%@)";
@@ -45,6 +50,9 @@
 
 /* Accessibility Label for query with unread mentions */
 "QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)";
+
+"QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
+"QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
 
 "NETWORK_ADD" = "Netzwerk hinzufügen";
 "CHANNEL_ADD" = "Raum betreten";
@@ -251,6 +259,10 @@
 "QUERY_DETAIL_MESSAGE_COPY" = "Copy";
 "QUERY_DETAIL_MESSAGE_MORE" = "More";
 
+"QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
+"QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
+"QUERY_DETAIL_REACTION_TEMPLATE" = "%@ reacted with %@"; // Untranslated
+
 /* Input bar */
 
 "INPUT_UPLOAD_IMAGE_LABEL" = "Ein Bild senden";
@@ -268,6 +280,16 @@
 "UPLOAD_IMAGE_POLICY_AGREE" = "Akzeptieren";
 
 "UPLOAD_IMAGE_PREFERENCES_TITLE" = "Bild-Uploads";
+"UPLOAD_IMAGE_PREFERENCES_LOGIN" = "Login"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_LOGOUT" = "Logout"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_ACCOUNT" = "Account"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_CHECKING" = "Checking account details"; // Untranslated
+
+"UPLOAD_IMAGE_ERROR_VIEW_SETTINGS" = "View Settings"; // Untranslated
+"UPLOAD_IMAGE_ERROR_ACCESS_NOT_PERMITTED" = "Access to photo library is not permitted. Enable access to photos in system settings."; // Untranslated
+"UPLOAD_IMAGE_ERROR_PARENTAL_CONTROL" = "Parental controls prevent access to photos."; // Untranslated
+"UPLOAD_IMAGE_ERROR_NO_IMAGE" = "Server did not return a string containing the image URL."; // Untranslated
+"UPLOAD_IMAGE_ERROR_INVALID_IMAGE" = "Invalid Image."; // Untranslated
 
 "CLOUDAPP_VERIFY_FAILURE" = "Login fehlgeschlagen, bitte erneut versuchen.";
 "CLOUDAPP_USERNAME" = "E-Mail";
@@ -341,16 +363,84 @@
 
 /* Channel Detail */
 "CHANNEL_DETAIL_TITLE" = "Raum Einstellungen";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS" = "Benachrichtigungen";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Benachrichtigungen";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "Alle Nachrichten";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Erwähnungen/Hervorhebungen";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Niemals";
 
 "CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
 "CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
+
+"CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
 "CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
 
 /* Modes View (View/Edit) Title */
 "CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+
+"CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
+"CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated
+"CHANNEL_MODE_M" = "Moderated (+m)"; // Untranslated
+"CHANNEL_MODE_P" = "Private (+p)"; // Untranslated
+"CHANNEL_MODE_S" = "Secret (+s)"; // Untranslated
+"CHANNEL_MODE_N" = "No external messages (+n)"; // Untranslated
+"CHANNEL_MODE_T" = "Only ops can set topic (+t)"; // Untranslated
+
+"CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
+
+/* URL Actions */
+"URL_ACTION_OPEN" = "Open"; // Untranslated
+"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
+"URL_ACTION_COPY" = "Copy"; // Untranslated
+"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
+
+/* Add Network */
+"ADD_NETWORK_POPULAR" = "Popular Networks"; // Untranslated
+"ADD_NETWORK_CUSTOM" = "Custom Network"; // Untranslated
+"ADD_NETWORK_SELECT" = "Select Network"; // Untranslated
+
+/* Connection Details */
+"CONNECTION_DETAIL_TITLE" = "Connection Info"; // Untranslated
+"CONNECTION_DETAIL_CHAIN" = "Certificate Chain"; // Untranslated
+"CERTIFICATE_DETAIL_FINGERPRINTS" = "Fingerprints"; // Untranslated
+
+/* Key Commands */
+"KEY_COMMAND_PREVIOUS_QUERY" = "Previous Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_UNREAD_QUERY" = "Previous Unread Query"; // Untranslated
+"KEY_COMMAND_NEXT_QUERY" = "Next Query"; // Untranslated
+"KEY_COMMAND_NEXT_UNREAD_QUERY" = "Next Unread Query"; // Untranslated
+"KEY_COMMAND_CLOSE_QUERY" = "Close Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_MESSAGE" = "Previous Message"; // Untranslated
+"KEY_COMMAND_NEXT_MESSAGE" = "Next Message"; // Untranslated
+
+/* User Commands */
+"COMMAND_NOT_CONNECTED" = "You are not connected"; // Untranslated
+"COMMAND_NOT_CONNECTED_NICK" = "'%@' alias uses {nick} while we are not connected to a server"; // Untranslated
+"COMMAND_NOT_CONNECTED_CHANNEL" = "'%@' alias uses {channel} while we are not in a channel query"; // Untranslated
+"COMMAND_NOT_JOINED" = "You are not joined"; // Untranslated
+
+"COMMAND_QUERY_INVALID" = "Not a query"; // Untranslated
+"COMMAND_QUERY_UNKNOWN" = "This query is not a channel or nick."; // Untranslated
+"COMMAND_QUERY_INVALID_TYPE" = "Incorrect query type"; // Untranslated
+"COMMAND_NETWORK_INVALID" = "Not a network query"; // Untranslated
+"COMMAND_NETWORK_NOT_FOUND" = "network '%@' not found"; // Untranslated
+"COMMAND_CHANNEL_INVALID" = "%@ is not a channel"; // Untranslated
+"COMMAND_CHANNEL_NOT_JOINED" = "%@ is not joined"; // Untranslated
+
+"COMMAND_RAW_NO_LINE" = "/raw was not given a line"; // Untranslated
+
+"COMMAND_ALIAS_DEFAULT_TITLE" = "Default Aliases:"; // Untranslated
+"COMMAND_ALIAS_TITLE" = "Aliases:"; // Untranslated
+"COMMAND_ALIAS_ALREADY_ADDED" = "Alias '%@' is already added"; // Untranslated
+"COMMAND_ALIAS_NOT_FOUND" = "Alias '%@' not found"; // Untranslated
+"COMMAND_ALIAS_REMOVE_ERROR" = "Cannot remove default alias '%@'"; // Untranslated
+"COMMAND_ALIAS_REMOVE" = "Alias '%@' removed"; // Untranslated
+
+"COMMAND_INVITE_MULTIPLE" = "Multiple channels provided to invite. Only one is allowed."; // Untranslated
+"COMMAND_MY_VERSION" = "/me is using {app} {appVersion} {appURL}"; // Untranslated
+"COMMAND_SYSINFO" = "/me is using {app} {appVersion} on an {platform} running {os} {osVersion}"; // Untranslated
+
+"COMMAND_UNKNOWN" = "Unknown Command: %@"; // Untranslated

--- a/de.lproj/Localizable.strings
+++ b/de.lproj/Localizable.strings
@@ -277,10 +277,6 @@
 "NICK_WHOIS" = "Whois";
 "WHOIS_CHANNELS_TITLE" = "Räume";
 
-/* Whois */
-"NICK_WHOIS" = "Whois";
-"WHOIS_CHANNELS_TITLE" = "Channels";
-
 /* Whois User Information Section */
 "WHOIS_USER_SECTION" = "Benutzer";
 

--- a/en.lproj/Localizable.strings
+++ b/en.lproj/Localizable.strings
@@ -11,6 +11,9 @@
 "CANCEL" = "Cancel";
 "CLOSE" = "Close";
 "OK" = "OK";
+"YES" = "Yes";
+"NO" = "No";
+"UNKNOWN" = "Unknown";
 
 "NICKNAME" = "Nickname";
 
@@ -25,6 +28,8 @@
 
 /* Body of notification when sending a message from a notification failed */
 "NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+
+"NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network.";
 
 "QUERY_LIST_TITLE" = "Chats";
 "QUERY_LIST_TITLE_UNREAD" = "Chats (%@)";
@@ -45,6 +50,9 @@
 
 /* Accessibility Label for query with unread mentions */
 "QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)";
+
+"QUERY_LIST_SEARCH" = "Search Messages";
+"QUERY_LIST_MARK_AS_READ" = "Mark as read";
 
 "NETWORK_ADD" = "Add Network";
 "CHANNEL_ADD" = "Join Channel";
@@ -251,6 +259,10 @@
 "QUERY_DETAIL_MESSAGE_COPY" = "Copy";
 "QUERY_DETAIL_MESSAGE_MORE" = "More";
 
+"QUERY_DETAIL_ADD_REACTION" = "Add Reaction";
+"QUERY_DETAIL_REACTION_TITLE" = "Reactions";
+"QUERY_DETAIL_REACTION_TEMPLATE" = "%@ reacted with %@";
+
 /* Input bar */
 
 "INPUT_UPLOAD_IMAGE_LABEL" = "Send an Image";
@@ -268,6 +280,16 @@
 "UPLOAD_IMAGE_POLICY_AGREE" = "Agree";
 
 "UPLOAD_IMAGE_PREFERENCES_TITLE" = "Image Uploads";
+"UPLOAD_IMAGE_PREFERENCES_LOGIN" = "Login";
+"UPLOAD_IMAGE_PREFERENCES_LOGOUT" = "Logout";
+"UPLOAD_IMAGE_PREFERENCES_ACCOUNT" = "Account";
+"UPLOAD_IMAGE_PREFERENCES_CHECKING" = "Checking account details";
+
+"UPLOAD_IMAGE_ERROR_VIEW_SETTINGS" = "View Settings";
+"UPLOAD_IMAGE_ERROR_ACCESS_NOT_PERMITTED" = "Access to photo library is not permitted. Enable access to photos in system settings.";
+"UPLOAD_IMAGE_ERROR_PARENTAL_CONTROL" = "Parental controls prevent access to photos.";
+"UPLOAD_IMAGE_ERROR_NO_IMAGE" = "Server did not return a string containing the image URL.";
+"UPLOAD_IMAGE_ERROR_INVALID_IMAGE" = "Invalid Image.";
 
 "CLOUDAPP_VERIFY_FAILURE" = "Account could not be verified, please try again.";
 "CLOUDAPP_USERNAME" = "Email";
@@ -341,16 +363,84 @@
 
 /* Channel Detail */
 "CHANNEL_DETAIL_TITLE" = "Channel Settings";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS" = "Message Notifications";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Message Notifications";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "All messages";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Mentions or highlights";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never";
 
 "CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
 "CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; 
+
+"CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count";
 
 /* View/Edit Channel Modes */
 "CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
 
 /* Modes View (View/Edit) Title */
 "CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+
+"CHANNEL_MODE_C" = "Disable color codes (+c)";
+"CHANNEL_MODE_I" = "Invite only (+i)";
+"CHANNEL_MODE_M" = "Moderated (+m)";
+"CHANNEL_MODE_P" = "Private (+p)";
+"CHANNEL_MODE_S" = "Secret (+s)";
+"CHANNEL_MODE_N" = "No external messages (+n)";
+"CHANNEL_MODE_T" = "Only ops can set topic (+t)";
+
+"CHANNEL_DETAIL_PART" = "Part Channel";
+
+/* URL Actions */
+"URL_ACTION_OPEN" = "Open";
+"URL_ACTION_READING_LIST" = "Add to Reading List";
+"URL_ACTION_COPY" = "Copy";
+"URL_ACTION_SHARE" = "Share...";
+"READING_LIST_NOTE" = "Saved from Palaver";
+
+/* Add Network */
+"ADD_NETWORK_POPULAR" = "Popular Networks";
+"ADD_NETWORK_CUSTOM" = "Custom Network";
+"ADD_NETWORK_SELECT" = "Select Network";
+
+/* Connection Details */
+"CONNECTION_DETAIL_TITLE" = "Connection Info";
+"CONNECTION_DETAIL_CHAIN" = "Certificate Chain";
+"CERTIFICATE_DETAIL_FINGERPRINTS" = "Fingerprints";
+
+/* Key Commands */
+"KEY_COMMAND_PREVIOUS_QUERY" = "Previous Query";
+"KEY_COMMAND_PREVIOUS_UNREAD_QUERY" = "Previous Unread Query";
+"KEY_COMMAND_NEXT_QUERY" = "Next Query";
+"KEY_COMMAND_NEXT_UNREAD_QUERY" = "Next Unread Query";
+"KEY_COMMAND_CLOSE_QUERY" = "Close Query";
+"KEY_COMMAND_PREVIOUS_MESSAGE" = "Previous Message";
+"KEY_COMMAND_NEXT_MESSAGE" = "Next Message";
+
+/* User Commands */
+"COMMAND_NOT_CONNECTED" = "You are not connected";
+"COMMAND_NOT_CONNECTED_NICK" = "'%@' alias uses {nick} while we are not connected to a server";
+"COMMAND_NOT_CONNECTED_CHANNEL" = "'%@' alias uses {channel} while we are not in a channel query";
+"COMMAND_NOT_JOINED" = "You are not joined";
+
+"COMMAND_QUERY_INVALID" = "Not a query";
+"COMMAND_QUERY_UNKNOWN" = "This query is not a channel or nick.";
+"COMMAND_QUERY_INVALID_TYPE" = "Incorrect query type";
+"COMMAND_NETWORK_INVALID" = "Not a network query";
+"COMMAND_NETWORK_NOT_FOUND" = "network '%@' not found";
+"COMMAND_CHANNEL_INVALID" = "%@ is not a channel";
+"COMMAND_CHANNEL_NOT_JOINED" = "%@ is not joined";
+
+"COMMAND_RAW_NO_LINE" = "/raw was not given a line";
+
+"COMMAND_ALIAS_DEFAULT_TITLE" = "Default Aliases:";
+"COMMAND_ALIAS_TITLE" = "Aliases:";
+"COMMAND_ALIAS_ALREADY_ADDED" = "Alias '%@' is already added";
+"COMMAND_ALIAS_NOT_FOUND" = "Alias '%@' not found";
+"COMMAND_ALIAS_REMOVE_ERROR" = "Cannot remove default alias '%@'";
+"COMMAND_ALIAS_REMOVE" = "Alias '%@' removed";
+
+"COMMAND_INVITE_MULTIPLE" = "Multiple channels provided to invite. Only one is allowed.";
+"COMMAND_MY_VERSION" = "/me is using {app} {appVersion} {appURL}";
+"COMMAND_SYSINFO" = "/me is using {app} {appVersion} on an {platform} running {os} {osVersion}";
+
+"COMMAND_UNKNOWN" = "Unknown Command: %@";

--- a/es.lproj/Localizable.strings
+++ b/es.lproj/Localizable.strings
@@ -277,10 +277,6 @@
 "NICK_WHOIS" = "Whois";
 "WHOIS_CHANNELS_TITLE" = "Canales";
 
-/* Whois */
-"NICK_WHOIS" = "Whois";
-"WHOIS_CHANNELS_TITLE" = "Channels";
-
 /* Whois User Information Section */
 "WHOIS_USER_SECTION" = "Usuario";
 
@@ -348,6 +344,7 @@
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS" = "Notificaciones de Mensajes";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "Todos los mensajes";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Menciones o palabras resaltadas";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never"; // Untranslated
 
 "CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
 "CHANNEL_DETAIL_NO_TOPIC" = "No Topic";

--- a/es.lproj/Localizable.strings
+++ b/es.lproj/Localizable.strings
@@ -18,16 +18,16 @@
 "NICKNAME" = "Apodo";
 
 /* Body of notification when message previews are disabled */
-"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message";
+"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message"; // Untranslated
 
 /* Reply button title for message notification */
-"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply";
+"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply"; // Untranslated
 
 /* Title of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message"; // Untranslated
 
 /* Body of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry"; // Untranslated
 
 "NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
@@ -37,19 +37,19 @@
 "QUERY_LIST_ADD_NETWORK_MESSAGE" = "¡Toque aquí para agregar tu primera red!";
 
 /* Accessibility label for connected network status */
-"QUERY_LIST_NETWORK_CONNECTED_STATUS" = "connected";
+"QUERY_LIST_NETWORK_CONNECTED_STATUS" = "connected"; // Untranslated
 
 /* Accessibility label for disconnected network status */
-"QUERY_LIST_NETWORK_DISCONNECTED_STATUS" = "disconnected";
+"QUERY_LIST_NETWORK_DISCONNECTED_STATUS" = "disconnected"; // Untranslated
 
 /* Accessibility label for connecting network status */
-"QUERY_LIST_NETWORK_CONNECTING_STATUS" = "connecting";
+"QUERY_LIST_NETWORK_CONNECTING_STATUS" = "connecting"; // Untranslated
 
 /* Accessibility Label for query */
-"QUERY_LIST_QUERY_LABEL" = "%@ (%@ unread)";
+"QUERY_LIST_QUERY_LABEL" = "%@ (%@ unread)"; // Untranslated
 
 /* Accessibility Label for query with unread mentions */
-"QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)";
+"QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)"; // Untranslated
 
 "QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
 "QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
@@ -105,12 +105,12 @@
 "NETWORK_EXPAND" = "Abrir";
 "NETWORK_CONNECT" = "Conectar";
 "NETWORK_DISCONNECT" = "Desconectar";
-"NETWORK_CHANGE_NICKNAME" = "Change Nickname";
-"NETWORK_CHANGE_NICKNAME_APPLY" = "Change";
-"NETWORK_CHANNEL_LIST" = "Channel List";
+"NETWORK_CHANGE_NICKNAME" = "Change Nickname"; // Untranslated
+"NETWORK_CHANGE_NICKNAME_APPLY" = "Change"; // Untranslated
+"NETWORK_CHANNEL_LIST" = "Channel List"; // Untranslated
 
 "NETWORK_ORDER" = "Orden";
-"NETWORK_REARRANGE" = "Sort Networks";
+"NETWORK_REARRANGE" = "Sort Networks"; // Untranslated
 
 "NETWORK_PASSWORD_INCORRECT" = "Clave incorrecta (%@)";
 
@@ -148,10 +148,10 @@
 "THEME_VARIANT_DARK" = "Oscuro";
 
 "GENERAL_AUTO_JOIN_CHANNELS" = "Auto-unirse a los canales";
-"GENERAL_AUTO_AWAY" = "Auto-away";
+"GENERAL_AUTO_AWAY" = "Auto-away"; // Untranslated
 
-"NOTIFICATIONS_TITLE" = "Notifications";
-"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews";
+"NOTIFICATIONS_TITLE" = "Notifications"; // Untranslated
+"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews"; // Untranslated
 
 "MENTIONS_TITLE" = "Menciones";
 "MENTIONS_ADD_TITLE" = "Añadir Palabra Resaltada";
@@ -224,13 +224,13 @@
 "QUERY_STATUS_NICK_IGNORED_ACTION" = "Toque aquí para dejar de ignorar este usuario.";
 
 /* Accessibility label for nicks in channel button */
-"QUERY_DETAIL_CHANNEL_NICKS_BUTTON_LABEL" = "Channel Members";
+"QUERY_DETAIL_CHANNEL_NICKS_BUTTON_LABEL" = "Channel Members"; // Untranslated
 
 /* Accessibility label for whois user button */
-"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User";
+"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User"; // Untranslated
 
 /* Accessibility label for scroll to bottom button */
-"QUERY_DETAIL_SCROLL_BOTTOM_BUTTON_LABEL" = "Scroll down to bottom of conversation";
+"QUERY_DETAIL_SCROLL_BOTTOM_BUTTON_LABEL" = "Scroll down to bottom of conversation"; // Untranslated
 
 /* Link Preview */
 "QUERY_DETAIL_LINK_PREVIEW_ENABLE" = "Habilitar Prevista de Enlaces";
@@ -239,25 +239,25 @@
 "QUERY_DETAIL_LINK_PREVIEW_ALL_LINKS" = "Todo el tiempo";
 
 /* Accessibility label for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message";
+"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message"; // Untranslated
 
 /* Accessibility hint for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options";
+"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options"; // Untranslated
 
 /* Message of alert when opening failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered"; // Untranslated
 
 /* Retry option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again"; // Untranslated
 
 /* Delete option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message"; // Untranslated
 
 /* Cancel option of alert for failed message retry options */
 "QUERY_DETAIL_FAILED_MESSAGE_ALERT_CANCEL" = "Cancelar";
 
-"QUERY_DETAIL_MESSAGE_COPY" = "Copy";
-"QUERY_DETAIL_MESSAGE_MORE" = "More";
+"QUERY_DETAIL_MESSAGE_COPY" = "Copy"; // Untranslated
+"QUERY_DETAIL_MESSAGE_MORE" = "More"; // Untranslated
 
 "QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
 "QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
@@ -303,46 +303,46 @@
 "WHOIS_USER_SECTION" = "Usuario";
 
 /* Whois Session Information Section */
-"WHOIS_SESSION_SECTION" = "Session Information";
+"WHOIS_SESSION_SECTION" = "Session Information"; // Untranslated
 
 /* Whois Server Information Section */
-"WHOIS_SERVER_SECTION" = "Server Information";
+"WHOIS_SERVER_SECTION" = "Server Information"; // Untranslated
 
 /* Whois User Realname */
-"WHOIS_USER_REALNAME" = "Realname";
+"WHOIS_USER_REALNAME" = "Realname"; // Untranslated
 
 /* Whois User Ident */
-"WHOIS_USER_IDENT" = "Ident";
+"WHOIS_USER_IDENT" = "Ident"; // Untranslated
 
 /* Whois User Hostname */
-"WHOIS_USER_HOSTNAME" = "Hostname";
+"WHOIS_USER_HOSTNAME" = "Hostname"; // Untranslated
 
 /* Whois User Is Network Operator */
-"WHOIS_USER_IS_NETWORK_OPERATOR" = "Network Operator";
+"WHOIS_USER_IS_NETWORK_OPERATOR" = "Network Operator"; // Untranslated
 
 /* Whois User Connection Status */
-"WHOIS_USER_CONNECTION_STATUS" = "Status";
+"WHOIS_USER_CONNECTION_STATUS" = "Status"; // Untranslated
 
 /* Whois User Connection Status (Connected) */
-"WHOIS_USER_CONNECTION_STATUS_CONNECTED" = "Connected";
+"WHOIS_USER_CONNECTION_STATUS_CONNECTED" = "Connected"; // Untranslated
 
 /* Whois User Connection Status (Disconnected) */
-"WHOIS_USER_CONNECTION_STATUS_DISCONNECTED" = "Offline";
+"WHOIS_USER_CONNECTION_STATUS_DISCONNECTED" = "Offline"; // Untranslated
 
 /* Whois Session Idle Time */
-"WHOIS_SESSION_IDLE_TIME" = "Idle";
+"WHOIS_SESSION_IDLE_TIME" = "Idle"; // Untranslated
 
 /* Whois Session Connected Time */
-"WHOIS_SESSION_CONNECTED_TIME" = "Connected";
+"WHOIS_SESSION_CONNECTED_TIME" = "Connected"; // Untranslated
 
 /* Whois Session Using TLS */
-"WHOIS_SESSION_USING_TLS" = "Using TLS";
+"WHOIS_SESSION_USING_TLS" = "Using TLS"; // Untranslated
 
 /* Whois Server Hostname */
 "WHOIS_SERVER_HOSTNAME" = "Servidor";
 
 /* Whois Server Information */
-"WHOIS_SERVER_INFO" = "Server Info";
+"WHOIS_SERVER_INFO" = "Server Info"; // Untranslated
 
 /* Media */
 "MEDIA_NOT_PLAYING" = "no esta reproduciendo nada";
@@ -368,17 +368,17 @@
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Menciones o palabras resaltadas";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never"; // Untranslated
 
-"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
-"CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic"; // Untranslated
+"CHANNEL_DETAIL_NO_TOPIC" = "No Topic"; // Untranslated
 "CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
 
 "CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
-"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
+"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes"; // Untranslated
 
 /* Modes View (View/Edit) Title */
-"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes"; // Untranslated
 
 "CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
 "CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated

--- a/es.lproj/Localizable.strings
+++ b/es.lproj/Localizable.strings
@@ -11,6 +11,9 @@
 "CANCEL" = "Cancelar";
 "CLOSE" = "Cerrar";
 "OK" = "OK";
+"YES" = "Yes"; // Untranslated
+"NO" = "No"; // Untranslated
+"UNKNOWN" = "Unknown"; // Untranslated
 
 "NICKNAME" = "Apodo";
 
@@ -25,6 +28,8 @@
 
 /* Body of notification when sending a message from a notification failed */
 "NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+
+"NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
 "QUERY_LIST_TITLE" = "Conversaciones";
 "QUERY_LIST_TITLE_UNREAD" = "Conversaciones (%@)";
@@ -45,6 +50,9 @@
 
 /* Accessibility Label for query with unread mentions */
 "QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ unread, with mentions)";
+
+"QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
+"QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
 
 "NETWORK_ADD" = "Agregar Red";
 "CHANNEL_ADD" = "Unirse a un Canal";
@@ -251,6 +259,10 @@
 "QUERY_DETAIL_MESSAGE_COPY" = "Copy";
 "QUERY_DETAIL_MESSAGE_MORE" = "More";
 
+"QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
+"QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
+"QUERY_DETAIL_REACTION_TEMPLATE" = "%@ reacted with %@"; // Untranslated
+
 /* Input bar */
 
 "INPUT_UPLOAD_IMAGE_LABEL" = "Mandar una Imagen";
@@ -268,6 +280,16 @@
 "UPLOAD_IMAGE_POLICY_AGREE" = "Acordar";
 
 "UPLOAD_IMAGE_PREFERENCES_TITLE" = "Subidas de Imágenes";
+"UPLOAD_IMAGE_PREFERENCES_LOGIN" = "Login"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_LOGOUT" = "Logout"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_ACCOUNT" = "Account"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_CHECKING" = "Checking account details"; // Untranslated
+
+"UPLOAD_IMAGE_ERROR_VIEW_SETTINGS" = "View Settings"; // Untranslated
+"UPLOAD_IMAGE_ERROR_ACCESS_NOT_PERMITTED" = "Access to photo library is not permitted. Enable access to photos in system settings."; // Untranslated
+"UPLOAD_IMAGE_ERROR_PARENTAL_CONTROL" = "Parental controls prevent access to photos."; // Untranslated
+"UPLOAD_IMAGE_ERROR_NO_IMAGE" = "Server did not return a string containing the image URL."; // Untranslated
+"UPLOAD_IMAGE_ERROR_INVALID_IMAGE" = "Invalid Image."; // Untranslated
 
 "CLOUDAPP_VERIFY_FAILURE" = "La cuenta no pudo ser validada, por favor intente otra vez.";
 "CLOUDAPP_USERNAME" = "Email";
@@ -341,16 +363,84 @@
 
 /* Channel Detail */
 "CHANNEL_DETAIL_TITLE" = "Configuración del Canal";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS" = "Notificaciones de Mensajes";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Notificaciones de Mensajes";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "Todos los mensajes";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Menciones o palabras resaltadas";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never"; // Untranslated
 
 "CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
 "CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
+
+"CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
 "CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
 
 /* Modes View (View/Edit) Title */
 "CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+
+"CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
+"CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated
+"CHANNEL_MODE_M" = "Moderated (+m)"; // Untranslated
+"CHANNEL_MODE_P" = "Private (+p)"; // Untranslated
+"CHANNEL_MODE_S" = "Secret (+s)"; // Untranslated
+"CHANNEL_MODE_N" = "No external messages (+n)"; // Untranslated
+"CHANNEL_MODE_T" = "Only ops can set topic (+t)"; // Untranslated
+
+"CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
+
+/* URL Actions */
+"URL_ACTION_OPEN" = "Open"; // Untranslated
+"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
+"URL_ACTION_COPY" = "Copy"; // Untranslated
+"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
+
+/* Add Network */
+"ADD_NETWORK_POPULAR" = "Popular Networks"; // Untranslated
+"ADD_NETWORK_CUSTOM" = "Custom Network"; // Untranslated
+"ADD_NETWORK_SELECT" = "Select Network"; // Untranslated
+
+/* Connection Details */
+"CONNECTION_DETAIL_TITLE" = "Connection Info"; // Untranslated
+"CONNECTION_DETAIL_CHAIN" = "Certificate Chain"; // Untranslated
+"CERTIFICATE_DETAIL_FINGERPRINTS" = "Fingerprints"; // Untranslated
+
+/* Key Commands */
+"KEY_COMMAND_PREVIOUS_QUERY" = "Previous Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_UNREAD_QUERY" = "Previous Unread Query"; // Untranslated
+"KEY_COMMAND_NEXT_QUERY" = "Next Query"; // Untranslated
+"KEY_COMMAND_NEXT_UNREAD_QUERY" = "Next Unread Query"; // Untranslated
+"KEY_COMMAND_CLOSE_QUERY" = "Close Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_MESSAGE" = "Previous Message"; // Untranslated
+"KEY_COMMAND_NEXT_MESSAGE" = "Next Message"; // Untranslated
+
+/* User Commands */
+"COMMAND_NOT_CONNECTED" = "You are not connected"; // Untranslated
+"COMMAND_NOT_CONNECTED_NICK" = "'%@' alias uses {nick} while we are not connected to a server"; // Untranslated
+"COMMAND_NOT_CONNECTED_CHANNEL" = "'%@' alias uses {channel} while we are not in a channel query"; // Untranslated
+"COMMAND_NOT_JOINED" = "You are not joined"; // Untranslated
+
+"COMMAND_QUERY_INVALID" = "Not a query"; // Untranslated
+"COMMAND_QUERY_UNKNOWN" = "This query is not a channel or nick."; // Untranslated
+"COMMAND_QUERY_INVALID_TYPE" = "Incorrect query type"; // Untranslated
+"COMMAND_NETWORK_INVALID" = "Not a network query"; // Untranslated
+"COMMAND_NETWORK_NOT_FOUND" = "network '%@' not found"; // Untranslated
+"COMMAND_CHANNEL_INVALID" = "%@ is not a channel"; // Untranslated
+"COMMAND_CHANNEL_NOT_JOINED" = "%@ is not joined"; // Untranslated
+
+"COMMAND_RAW_NO_LINE" = "/raw was not given a line"; // Untranslated
+
+"COMMAND_ALIAS_DEFAULT_TITLE" = "Default Aliases:"; // Untranslated
+"COMMAND_ALIAS_TITLE" = "Aliases:"; // Untranslated
+"COMMAND_ALIAS_ALREADY_ADDED" = "Alias '%@' is already added"; // Untranslated
+"COMMAND_ALIAS_NOT_FOUND" = "Alias '%@' not found"; // Untranslated
+"COMMAND_ALIAS_REMOVE_ERROR" = "Cannot remove default alias '%@'"; // Untranslated
+"COMMAND_ALIAS_REMOVE" = "Alias '%@' removed"; // Untranslated
+
+"COMMAND_INVITE_MULTIPLE" = "Multiple channels provided to invite. Only one is allowed."; // Untranslated
+"COMMAND_MY_VERSION" = "/me is using {app} {appVersion} {appURL}"; // Untranslated
+"COMMAND_SYSINFO" = "/me is using {app} {appVersion} on an {platform} running {os} {osVersion}"; // Untranslated
+
+"COMMAND_UNKNOWN" = "Unknown Command: %@"; // Untranslated

--- a/es.lproj/Localizable.strings
+++ b/es.lproj/Localizable.strings
@@ -391,10 +391,10 @@
 "CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
 
 /* URL Actions */
-"URL_ACTION_OPEN" = "Open"; // Untranslated
-"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
-"URL_ACTION_COPY" = "Copy"; // Untranslated
-"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"URL_ACTION_OPEN" = "Abrir";
+"URL_ACTION_READING_LIST" = "Agregar a lecturas";
+"URL_ACTION_COPY" = "Copiar";
+"URL_ACTION_SHARE" = "Compartir...";
 "READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
 
 /* Add Network */

--- a/ja.lproj/Localizable.strings
+++ b/ja.lproj/Localizable.strings
@@ -18,16 +18,16 @@
 "NICKNAME" = "ニックネーム";
 
 /* Body of notification when message previews are disabled */
-"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message";
+"NOTIFICATION_MESSAGE_CATEGORY_PRIVATE_BODY" = "Message"; // Untranslated
 
 /* Reply button title for message notification */
-"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply";
+"NOTIFICATION_MESSAGE_CATEGORY_REPLY_ACTION_TITLE" = "Reply"; // Untranslated
 
 /* Title of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_TITLE" = "Failed to send message"; // Untranslated
 
 /* Body of notification when sending a message from a notification failed */
-"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+"NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry"; // Untranslated
 
 "NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
@@ -87,7 +87,7 @@
 "NETWORK_PASSWORD" = "パスワード";
 "NETWORK_AUTOCONNECT" = "自動接続";
 "NETWORK_DELETE" = "ネットワークを削除";
-"NETWORK_IGNORED_NICKS" = "Ignored Nicknames";
+"NETWORK_IGNORED_NICKS" = "Ignored Nicknames"; // Untranslated
 
 "NETWORK_AUTHENTICATION" = "認証";
 "NETWORK_AUTHENTICATION_USERNAME" = "ユーザ名";
@@ -105,12 +105,12 @@
 "NETWORK_EXPAND" = "Queryを表示";
 "NETWORK_CONNECT" = "接続";
 "NETWORK_DISCONNECT" = "切断";
-"NETWORK_CHANGE_NICKNAME" = "Change Nickname";
-"NETWORK_CHANGE_NICKNAME_APPLY" = "Change";
-"NETWORK_CHANNEL_LIST" = "Channel List";
+"NETWORK_CHANGE_NICKNAME" = "Change Nickname"; // Untranslated
+"NETWORK_CHANGE_NICKNAME_APPLY" = "Change"; // Untranslated
+"NETWORK_CHANNEL_LIST" = "Channel List"; // Untranslated
 
 "NETWORK_ORDER" = "順序付ける";
-"NETWORK_REARRANGE" = "Sort Networks";
+"NETWORK_REARRANGE" = "Sort Networks"; // Untranslated
 
 "NETWORK_PASSWORD_INCORRECT" = "パスワードが正しくありません (%@)";
 
@@ -150,8 +150,8 @@
 "GENERAL_AUTO_JOIN_CHANNELS" = "チャンネルに自動接続";
 "GENERAL_AUTO_AWAY" = "自動離席";
 
-"NOTIFICATIONS_TITLE" = "Notifications";
-"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews";
+"NOTIFICATIONS_TITLE" = "Notifications"; // Untranslated
+"NOTIFICATIONS_SHOW_MESSAGE_PREVIEW" = "Show Message Previews"; // Untranslated
 
 "MENTIONS_TITLE" = "論及";
 "MENTIONS_ADD_TITLE" = "キーワードに参加";
@@ -190,21 +190,21 @@
 "IRC_CHANNEL_MODE_PLURAL_q" = "Owner";
 "IRC_CHANNEL_MODE_VERBOSE_PLURAL_q" = "Owner";
 
-"IRC_CHANNEL_MODE_a" = "Protected";
-"IRC_CHANNEL_MODE_PLURAL_a" = "Protected";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_a" = "Protected";
+"IRC_CHANNEL_MODE_a" = "Protected"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_a" = "Protected"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_a" = "Protected"; // Untranslated
 
-"IRC_CHANNEL_MODE_o" = "Op";
-"IRC_CHANNEL_MODE_PLURAL_o" = "Op";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_o" = "Operator";
+"IRC_CHANNEL_MODE_o" = "Op"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_o" = "Op"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_o" = "Operator"; // Untranslated
 
-"IRC_CHANNEL_MODE_h" = "Half-op";
-"IRC_CHANNEL_MODE_PLURAL_h" = "Half-op";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_h" = "Half-Operator";
+"IRC_CHANNEL_MODE_h" = "Half-op"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_h" = "Half-op"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_h" = "Half-Operator"; // Untranslated
 
-"IRC_CHANNEL_MODE_v" = "Voice";
-"IRC_CHANNEL_MODE_PLURAL_v" = "Voice";
-"IRC_CHANNEL_MODE_VERBOSE_PLURAL_v" = "Voice";
+"IRC_CHANNEL_MODE_v" = "Voice"; // Untranslated
+"IRC_CHANNEL_MODE_PLURAL_v" = "Voice"; // Untranslated
+"IRC_CHANNEL_MODE_VERBOSE_PLURAL_v" = "Voice"; // Untranslated
 
 /* Notifications */
 "IRC_CHANNEL_INVITATION" = "%@が%@に%@で招待しました";
@@ -220,38 +220,38 @@
 "QUERY_STATUS_CONNECTING" = "接続しっています。。。";
 "QUERY_STATUS_NICK_OFFLINE" = "ユーザがオフライン";
 
-"QUERY_STATUS_NICK_IGNORED" = "Nickname Ignored";
-"QUERY_STATUS_NICK_IGNORED_ACTION" = "Tap here to stop ignoring this user.";
+"QUERY_STATUS_NICK_IGNORED" = "Nickname Ignored"; // Untranslated
+"QUERY_STATUS_NICK_IGNORED_ACTION" = "Tap here to stop ignoring this user."; // Untranslated
 
 /* Accessibility label for nicks in channel button */
 "QUERY_DETAIL_CHANNEL_NICKS_BUTTON_LABEL" = "チャンネルの会員";
 
 /* Accessibility label for whois user button */
-"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User";
+"QUERY_DETAIL_WHOIS_BUTTON_LABEL" = "Who is User"; // Untranslated
 
 /* Accessibility label for scroll to bottom button */
 "QUERY_DETAIL_SCROLL_BOTTOM_BUTTON_LABEL" = "会話の切りでスクロールダウン";
 
 /* Accessibility label for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message";
+"QUERY_DETAIL_FAILED_MESSAGE_LABEL" = "Failed to send message"; // Untranslated
 
 /* Accessibility hint for the failed message retry button */
-"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options";
+"QUERY_DETAIL_FAILED_MESSAGE_HINT" = "Retry Options"; // Untranslated
 
 /* Message of alert when opening failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_MESSAGE" = "Message was not delivered"; // Untranslated
 
 /* Retry option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_RETRY" = "Try Again"; // Untranslated
 
 /* Delete option of alert for failed message retry options */
-"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message";
+"QUERY_DETAIL_FAILED_MESSAGE_ALERT_DELETE" = "Delete Message"; // Untranslated
 
 /* Cancel option of alert for failed message retry options */
 "QUERY_DETAIL_FAILED_MESSAGE_ALERT_CANCEL" = "キャンセル";
 
-"QUERY_DETAIL_MESSAGE_COPY" = "Copy";
-"QUERY_DETAIL_MESSAGE_MORE" = "More";
+"QUERY_DETAIL_MESSAGE_COPY" = "Copy"; // Untranslated
+"QUERY_DETAIL_MESSAGE_MORE" = "More"; // Untranslated
 
 "QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
 "QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
@@ -350,11 +350,11 @@
 "MEDIA_PLAYING_TITLE_ARTIST" = "is %@ %@ by %@";
 "MEDIA_PLAYING_TITLE_ALBUM" = "is %@ %@ from %@";
 "MEDIA_PLAYING_TITLE" = "is %@ %@";
-"MEDIA_PLAYING_ERROR" = "Cannot find media information.";
+"MEDIA_PLAYING_ERROR" = "Cannot find media information."; // Untranslated
 
-"MEDIA_VERB_AUDIO" = "listening to";
-"MEDIA_VERB_VIDEO" = "watching";
-"MEDIA_VERB_ALL" = "playing";
+"MEDIA_VERB_AUDIO" = "listening to"; // Untranslated
+"MEDIA_VERB_VIDEO" = "watching"; // Untranslated
+"MEDIA_VERB_ALL" = "playing"; // Untranslated
 
 "NICK_LIST" = "人民";
 
@@ -368,8 +368,8 @@
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "論及とハイライト";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "決して";
 
-"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
-"CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic"; // Untranslated
+"CHANNEL_DETAIL_NO_TOPIC" = "No Topic"; // Untranslated
 "CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
 
 "CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated

--- a/ja.lproj/Localizable.strings
+++ b/ja.lproj/Localizable.strings
@@ -391,10 +391,10 @@
 "CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
 
 /* URL Actions */
-"URL_ACTION_OPEN" = "Open"; // Untranslated
-"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
-"URL_ACTION_COPY" = "Copy"; // Untranslated
-"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"URL_ACTION_OPEN" = "開く";
+"URL_ACTION_READING_LIST" = "リーディングリストに追加";
+"URL_ACTION_COPY" = "コピー";
+"URL_ACTION_SHARE" = "共有...";
 "READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
 
 /* Add Network */

--- a/ja.lproj/Localizable.strings
+++ b/ja.lproj/Localizable.strings
@@ -11,6 +11,9 @@
 "CANCEL" = "キャンセル";
 "CLOSE" = "閉じる";
 "OK" = "OK";
+"YES" = "Yes"; // Untranslated
+"NO" = "No"; // Untranslated
+"UNKNOWN" = "Unknown"; // Untranslated
 
 "NICKNAME" = "ニックネーム";
 
@@ -25,6 +28,8 @@
 
 /* Body of notification when sending a message from a notification failed */
 "NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open application to retry";
+
+"NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
 "QUERY_LIST_TITLE" = "チャット";
 "QUERY_LIST_TITLE_UNREAD" = "チャット (%@)";
@@ -45,6 +50,9 @@
 
 /* Accessibility Label for query with unread mentions */
 "QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@（未読の%@個とメンション）";
+
+"QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
+"QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
 
 "NETWORK_ADD" = "ネットワークを連ねる";
 "CHANNEL_ADD" = "チャンネルに参加";
@@ -245,6 +253,10 @@
 "QUERY_DETAIL_MESSAGE_COPY" = "Copy";
 "QUERY_DETAIL_MESSAGE_MORE" = "More";
 
+"QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
+"QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
+"QUERY_DETAIL_REACTION_TEMPLATE" = "%@ reacted with %@"; // Untranslated
+
 /* Link Preview */
 "QUERY_DETAIL_LINK_PREVIEW_ENABLE" = "URLプレビューをイネーブル";
 "QUERY_DETAIL_LINK_PREVIEW_DISABLE" = "URLプレビューをディスエーブル";
@@ -268,6 +280,16 @@
 "UPLOAD_IMAGE_POLICY_AGREE" = "心得る";
 
 "UPLOAD_IMAGE_PREFERENCES_TITLE" = "画像のアップロード";
+"UPLOAD_IMAGE_PREFERENCES_LOGIN" = "Login"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_LOGOUT" = "Logout"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_ACCOUNT" = "Account"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_CHECKING" = "Checking account details"; // Untranslated
+
+"UPLOAD_IMAGE_ERROR_VIEW_SETTINGS" = "View Settings"; // Untranslated
+"UPLOAD_IMAGE_ERROR_ACCESS_NOT_PERMITTED" = "Access to photo library is not permitted. Enable access to photos in system settings."; // Untranslated
+"UPLOAD_IMAGE_ERROR_PARENTAL_CONTROL" = "Parental controls prevent access to photos."; // Untranslated
+"UPLOAD_IMAGE_ERROR_NO_IMAGE" = "Server did not return a string containing the image URL."; // Untranslated
+"UPLOAD_IMAGE_ERROR_INVALID_IMAGE" = "Invalid Image."; // Untranslated
 
 "CLOUDAPP_VERIFY_FAILURE" = "アカウントが糺しません。再試行してください。";
 "CLOUDAPP_USERNAME" = "電子メール";
@@ -341,16 +363,84 @@
 
 /* Channel Detail */
 "CHANNEL_DETAIL_TITLE" = "チャンネル設定";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS" = "メッセージ通知";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "メッセージ通知";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "すべてのメッセージ";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "論及とハイライト";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "決して";
 
 "CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
 "CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
+
+"CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
 "CHANNEL_DETAIL_VIEW_MODES" = "チャンネルの会話形";
 
 /* Modes View (View/Edit) Title */
 "CHANNEL_DETAIL_MODES_TITLE" = "チャンネルの会話形";
+
+"CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
+"CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated
+"CHANNEL_MODE_M" = "Moderated (+m)"; // Untranslated
+"CHANNEL_MODE_P" = "Private (+p)"; // Untranslated
+"CHANNEL_MODE_S" = "Secret (+s)"; // Untranslated
+"CHANNEL_MODE_N" = "No external messages (+n)"; // Untranslated
+"CHANNEL_MODE_T" = "Only ops can set topic (+t)"; // Untranslated
+
+"CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
+
+/* URL Actions */
+"URL_ACTION_OPEN" = "Open"; // Untranslated
+"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
+"URL_ACTION_COPY" = "Copy"; // Untranslated
+"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
+
+/* Add Network */
+"ADD_NETWORK_POPULAR" = "Popular Networks"; // Untranslated
+"ADD_NETWORK_CUSTOM" = "Custom Network"; // Untranslated
+"ADD_NETWORK_SELECT" = "Select Network"; // Untranslated
+
+/* Connection Details */
+"CONNECTION_DETAIL_TITLE" = "Connection Info"; // Untranslated
+"CONNECTION_DETAIL_CHAIN" = "Certificate Chain"; // Untranslated
+"CERTIFICATE_DETAIL_FINGERPRINTS" = "Fingerprints"; // Untranslated
+
+/* Key Commands */
+"KEY_COMMAND_PREVIOUS_QUERY" = "Previous Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_UNREAD_QUERY" = "Previous Unread Query"; // Untranslated
+"KEY_COMMAND_NEXT_QUERY" = "Next Query"; // Untranslated
+"KEY_COMMAND_NEXT_UNREAD_QUERY" = "Next Unread Query"; // Untranslated
+"KEY_COMMAND_CLOSE_QUERY" = "Close Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_MESSAGE" = "Previous Message"; // Untranslated
+"KEY_COMMAND_NEXT_MESSAGE" = "Next Message"; // Untranslated
+
+/* User Commands */
+"COMMAND_NOT_CONNECTED" = "You are not connected"; // Untranslated
+"COMMAND_NOT_CONNECTED_NICK" = "'%@' alias uses {nick} while we are not connected to a server"; // Untranslated
+"COMMAND_NOT_CONNECTED_CHANNEL" = "'%@' alias uses {channel} while we are not in a channel query"; // Untranslated
+"COMMAND_NOT_JOINED" = "You are not joined"; // Untranslated
+
+"COMMAND_QUERY_INVALID" = "Not a query"; // Untranslated
+"COMMAND_QUERY_UNKNOWN" = "This query is not a channel or nick."; // Untranslated
+"COMMAND_QUERY_INVALID_TYPE" = "Incorrect query type"; // Untranslated
+"COMMAND_NETWORK_INVALID" = "Not a network query"; // Untranslated
+"COMMAND_NETWORK_NOT_FOUND" = "network '%@' not found"; // Untranslated
+"COMMAND_CHANNEL_INVALID" = "%@ is not a channel"; // Untranslated
+"COMMAND_CHANNEL_NOT_JOINED" = "%@ is not joined"; // Untranslated
+
+"COMMAND_RAW_NO_LINE" = "/raw was not given a line"; // Untranslated
+
+"COMMAND_ALIAS_DEFAULT_TITLE" = "Default Aliases:"; // Untranslated
+"COMMAND_ALIAS_TITLE" = "Aliases:"; // Untranslated
+"COMMAND_ALIAS_ALREADY_ADDED" = "Alias '%@' is already added"; // Untranslated
+"COMMAND_ALIAS_NOT_FOUND" = "Alias '%@' not found"; // Untranslated
+"COMMAND_ALIAS_REMOVE_ERROR" = "Cannot remove default alias '%@'"; // Untranslated
+"COMMAND_ALIAS_REMOVE" = "Alias '%@' removed"; // Untranslated
+
+"COMMAND_INVITE_MULTIPLE" = "Multiple channels provided to invite. Only one is allowed."; // Untranslated
+"COMMAND_MY_VERSION" = "/me is using {app} {appVersion} {appURL}"; // Untranslated
+"COMMAND_SYSINFO" = "/me is using {app} {appVersion} on an {platform} running {os} {osVersion}"; // Untranslated
+
+"COMMAND_UNKNOWN" = "Unknown Command: %@"; // Untranslated

--- a/nl.lproj/Localizable.strings
+++ b/nl.lproj/Localizable.strings
@@ -391,10 +391,10 @@
 "CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
 
 /* URL Actions */
-"URL_ACTION_OPEN" = "Open"; // Untranslated
-"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
-"URL_ACTION_COPY" = "Copy"; // Untranslated
-"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"URL_ACTION_OPEN" = "Open";
+"URL_ACTION_READING_LIST" = "Zet in leeslijst";
+"URL_ACTION_COPY" = "Kopieer";
+"URL_ACTION_SHARE" = "Deel...";
 "READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
 
 /* Add Network */

--- a/nl.lproj/Localizable.strings
+++ b/nl.lproj/Localizable.strings
@@ -11,6 +11,9 @@
 "CANCEL" = "Annuleren";
 "CLOSE" = "Sluiten";
 "OK" = "Ok";
+"YES" = "Yes"; // Untranslated
+"NO" = "No"; // Untranslated
+"UNKNOWN" = "Unknown"; // Untranslated
 
 "NICKNAME" = "Bijnaam";
 
@@ -25,6 +28,8 @@
 
 /* Body of notification when sending a message from a notification failed */
 "NOTIFICATION_MESSAGE_CATEGORY_FAILED_BODY" = "Open Palaver om opnieuw te proberen";
+
+"NOTIFICATION_REPLY_FAILED" = "Failed to send message '%@'. Unknown or deleted IRC Network."; // Untranslated
 
 "QUERY_LIST_TITLE" = "Gesprekken";
 "QUERY_LIST_TITLE_UNREAD" = "Gesprekken (%@)";
@@ -45,6 +50,9 @@
 
 /* Accessibility Label for query with unread mentions */
 "QUERY_LIST_QUERY_UNREAD_MENTIONS_LABEL" = "%@ (%@ ongelezen, met mentions)";
+
+"QUERY_LIST_SEARCH" = "Search Messages"; // Untranslated
+"QUERY_LIST_MARK_AS_READ" = "Mark as read"; // Untranslated
 
 "NETWORK_ADD" = "Netwerk toevoegen";
 "CHANNEL_ADD" = "Betreed kanaal";
@@ -251,6 +259,10 @@
 "QUERY_DETAIL_MESSAGE_COPY" = "Copy";
 "QUERY_DETAIL_MESSAGE_MORE" = "More";
 
+"QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
+"QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
+"QUERY_DETAIL_REACTION_TEMPLATE" = "%@ reacted with %@"; // Untranslated
+
 /* Input bar */
 
 "INPUT_UPLOAD_IMAGE_LABEL" = "Stuur een afbeelding";
@@ -268,6 +280,16 @@
 "UPLOAD_IMAGE_POLICY_AGREE" = "Accepteren";
 
 "UPLOAD_IMAGE_PREFERENCES_TITLE" = "Afbeelding uploaden";
+"UPLOAD_IMAGE_PREFERENCES_LOGIN" = "Login"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_LOGOUT" = "Logout"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_ACCOUNT" = "Account"; // Untranslated
+"UPLOAD_IMAGE_PREFERENCES_CHECKING" = "Checking account details"; // Untranslated
+
+"UPLOAD_IMAGE_ERROR_VIEW_SETTINGS" = "View Settings"; // Untranslated
+"UPLOAD_IMAGE_ERROR_ACCESS_NOT_PERMITTED" = "Access to photo library is not permitted. Enable access to photos in system settings."; // Untranslated
+"UPLOAD_IMAGE_ERROR_PARENTAL_CONTROL" = "Parental controls prevent access to photos."; // Untranslated
+"UPLOAD_IMAGE_ERROR_NO_IMAGE" = "Server did not return a string containing the image URL."; // Untranslated
+"UPLOAD_IMAGE_ERROR_INVALID_IMAGE" = "Invalid Image."; // Untranslated
 
 "CLOUDAPP_VERIFY_FAILURE" = "Account kon niet worden geverifieerd, probeer het later opnieuw.";
 "CLOUDAPP_USERNAME" = "E-mail";
@@ -341,16 +363,84 @@
 
 /* Channel Detail */
 "CHANNEL_DETAIL_TITLE" = "Kanaal instellingen";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS" = "Bericht notificaties";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Bericht notificaties";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "Alle berichten";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Vermeldingen of highlights";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never";
 
 "CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
 "CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
+
+"CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
 "CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
 
 /* Modes View (View/Edit) Title */
 "CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+
+"CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
+"CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated
+"CHANNEL_MODE_M" = "Moderated (+m)"; // Untranslated
+"CHANNEL_MODE_P" = "Private (+p)"; // Untranslated
+"CHANNEL_MODE_S" = "Secret (+s)"; // Untranslated
+"CHANNEL_MODE_N" = "No external messages (+n)"; // Untranslated
+"CHANNEL_MODE_T" = "Only ops can set topic (+t)"; // Untranslated
+
+"CHANNEL_DETAIL_PART" = "Part Channel"; // Untranslated
+
+/* URL Actions */
+"URL_ACTION_OPEN" = "Open"; // Untranslated
+"URL_ACTION_READING_LIST" = "Add to Reading List"; // Untranslated
+"URL_ACTION_COPY" = "Copy"; // Untranslated
+"URL_ACTION_SHARE" = "Share..."; // Untranslated
+"READING_LIST_NOTE" = "Saved from Palaver"; // Untranslated
+
+/* Add Network */
+"ADD_NETWORK_POPULAR" = "Popular Networks"; // Untranslated
+"ADD_NETWORK_CUSTOM" = "Custom Network"; // Untranslated
+"ADD_NETWORK_SELECT" = "Select Network"; // Untranslated
+
+/* Connection Details */
+"CONNECTION_DETAIL_TITLE" = "Connection Info"; // Untranslated
+"CONNECTION_DETAIL_CHAIN" = "Certificate Chain"; // Untranslated
+"CERTIFICATE_DETAIL_FINGERPRINTS" = "Fingerprints"; // Untranslated
+
+/* Key Commands */
+"KEY_COMMAND_PREVIOUS_QUERY" = "Previous Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_UNREAD_QUERY" = "Previous Unread Query"; // Untranslated
+"KEY_COMMAND_NEXT_QUERY" = "Next Query"; // Untranslated
+"KEY_COMMAND_NEXT_UNREAD_QUERY" = "Next Unread Query"; // Untranslated
+"KEY_COMMAND_CLOSE_QUERY" = "Close Query"; // Untranslated
+"KEY_COMMAND_PREVIOUS_MESSAGE" = "Previous Message"; // Untranslated
+"KEY_COMMAND_NEXT_MESSAGE" = "Next Message"; // Untranslated
+
+/* User Commands */
+"COMMAND_NOT_CONNECTED" = "You are not connected"; // Untranslated
+"COMMAND_NOT_CONNECTED_NICK" = "'%@' alias uses {nick} while we are not connected to a server"; // Untranslated
+"COMMAND_NOT_CONNECTED_CHANNEL" = "'%@' alias uses {channel} while we are not in a channel query"; // Untranslated
+"COMMAND_NOT_JOINED" = "You are not joined"; // Untranslated
+
+"COMMAND_QUERY_INVALID" = "Not a query"; // Untranslated
+"COMMAND_QUERY_UNKNOWN" = "This query is not a channel or nick."; // Untranslated
+"COMMAND_QUERY_INVALID_TYPE" = "Incorrect query type"; // Untranslated
+"COMMAND_NETWORK_INVALID" = "Not a network query"; // Untranslated
+"COMMAND_NETWORK_NOT_FOUND" = "network '%@' not found"; // Untranslated
+"COMMAND_CHANNEL_INVALID" = "%@ is not a channel"; // Untranslated
+"COMMAND_CHANNEL_NOT_JOINED" = "%@ is not joined"; // Untranslated
+
+"COMMAND_RAW_NO_LINE" = "/raw was not given a line"; // Untranslated
+
+"COMMAND_ALIAS_DEFAULT_TITLE" = "Default Aliases:"; // Untranslated
+"COMMAND_ALIAS_TITLE" = "Aliases:"; // Untranslated
+"COMMAND_ALIAS_ALREADY_ADDED" = "Alias '%@' is already added"; // Untranslated
+"COMMAND_ALIAS_NOT_FOUND" = "Alias '%@' not found"; // Untranslated
+"COMMAND_ALIAS_REMOVE_ERROR" = "Cannot remove default alias '%@'"; // Untranslated
+"COMMAND_ALIAS_REMOVE" = "Alias '%@' removed"; // Untranslated
+
+"COMMAND_INVITE_MULTIPLE" = "Multiple channels provided to invite. Only one is allowed."; // Untranslated
+"COMMAND_MY_VERSION" = "/me is using {app} {appVersion} {appURL}"; // Untranslated
+"COMMAND_SYSINFO" = "/me is using {app} {appVersion} on an {platform} running {os} {osVersion}"; // Untranslated
+
+"COMMAND_UNKNOWN" = "Unknown Command: %@"; // Untranslated

--- a/nl.lproj/Localizable.strings
+++ b/nl.lproj/Localizable.strings
@@ -105,12 +105,12 @@
 "NETWORK_EXPAND" = "Uitklappen";
 "NETWORK_CONNECT" = "Verbinden";
 "NETWORK_DISCONNECT" = "Verbinding verbreken";
-"NETWORK_CHANGE_NICKNAME" = "Change Nickname";
-"NETWORK_CHANGE_NICKNAME_APPLY" = "Change";
-"NETWORK_CHANNEL_LIST" = "Channel List";
+"NETWORK_CHANGE_NICKNAME" = "Change Nickname"; // Untranslated
+"NETWORK_CHANGE_NICKNAME_APPLY" = "Change"; // Untranslated
+"NETWORK_CHANNEL_LIST" = "Channel List"; // Untranslated
 
 "NETWORK_ORDER" = "Volgorde";
-"NETWORK_REARRANGE" = "Sort Networks";
+"NETWORK_REARRANGE" = "Sort Networks"; // Untranslated
 
 "NETWORK_PASSWORD_INCORRECT" = "Wachtwoord onjuist (%@)";
 
@@ -256,8 +256,8 @@
 /* Cancel option of alert for failed message retry options */
 "QUERY_DETAIL_FAILED_MESSAGE_ALERT_CANCEL" = "Annuleren";
 
-"QUERY_DETAIL_MESSAGE_COPY" = "Copy";
-"QUERY_DETAIL_MESSAGE_MORE" = "More";
+"QUERY_DETAIL_MESSAGE_COPY" = "Copy"; // Untranslated
+"QUERY_DETAIL_MESSAGE_MORE" = "More"; // Untranslated
 
 "QUERY_DETAIL_ADD_REACTION" = "Add Reaction"; // Untranslated
 "QUERY_DETAIL_REACTION_TITLE" = "Reactions"; // Untranslated
@@ -359,26 +359,26 @@
 "NICK_LIST" = "Personen";
 
 /* Channel List */
-"CHANNEL_LIST_TITLE" = "Channels";
+"CHANNEL_LIST_TITLE" = "Channels"; // Untranslated
 
 /* Channel Detail */
 "CHANNEL_DETAIL_TITLE" = "Kanaal instellingen";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_SECTION" = "Bericht notificaties";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_ALL" = "Alle berichten";
 "CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_MENTIONS" = "Vermeldingen of highlights";
-"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never";
+"CHANNEL_DETAIL_MESSAGE_NOTIFICATIONS_NEVER" = "Never"; // Untranslated
 
-"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic";
-"CHANNEL_DETAIL_NO_TOPIC" = "No Topic";
+"CHANNEL_DETAIL_TOPIC_SECTION" = "Topic"; // Untranslated
+"CHANNEL_DETAIL_NO_TOPIC" = "No Topic"; // Untranslated
 "CHANNEL_DETAIL_TOPIC_EDIT" = "Edit"; // Untranslated
 
 "CHANNEL_DETAIL_UNREAD_COUNT_SECTION" = "Unread Count"; // Untranslated
 
 /* View/Edit Channel Modes */
-"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes";
+"CHANNEL_DETAIL_VIEW_MODES" = "Channel Modes"; // Untranslated
 
 /* Modes View (View/Edit) Title */
-"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes";
+"CHANNEL_DETAIL_MODES_TITLE" = "Channel Modes"; // Untranslated
 
 "CHANNEL_MODE_C" = "Disable color codes (+c)"; // Untranslated
 "CHANNEL_MODE_I" = "Invite only (+i)"; // Untranslated


### PR DESCRIPTION
This PR adds missing translation identifiers from Palaver. In addition, it tags all strings that are currently not translated with a comment, making it easier for translators to find the strings that are untranslated.